### PR TITLE
[FE] OAuth access token 발급 후 일기장 리스트 페이지로 자동 redirect

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "react-router-dom": "^6.6.2",
     "react-scripts": "5.0.1",
     "recoil": "^0.7.6",
+    "recoil-persist": "^4.2.0",
     "typescript": "^4.9.4",
     "web-vitals": "^2.1.4",
     "webpack": "^5.75.0"

--- a/client/src/constants/API_URL.tsx
+++ b/client/src/constants/API_URL.tsx
@@ -2,6 +2,7 @@ export const API_URL = Object.freeze({
   kakaoLogin: "/api/login/kakao",
   naverLogin: "/api/login/naver",
   emailLogin: "/api/login/local",
+  refreshToken: "/api/login/silent-refresh",
   books: "/api/books",
   book: function (bookId: number) {
     return this.books + `/${bookId}`;

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,11 +1,15 @@
-import React, { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import React from "react";
+import { useRecoilState } from "recoil";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import tw from "tailwind-styled-components";
 import Fade from "react-reveal/Fade";
 
-import { getCookieValue } from "src/utils/cookie";
-import { Keys } from "src/constants/Keys";
+import { accessTokenAtom } from "src/recoil/token";
+import { Token } from "src/recoil/token/atom";
 import { PRIVATE_ROUTE } from "src/router/ROUTE_INFO";
+import { refreshToken } from "../utils/token";
+import { useDidMountEffect } from "src/utils/hooks";
+
 import { DefaultBackground } from "src/components/common/Backgrounds";
 import "src/components/common/Backgrounds.css";
 import { Greeting } from "src/components/home/Greeting";
@@ -20,13 +24,23 @@ w-[80%] py-[2vh] mt-[2vh] min-[390px]:mt-[6vh] mx-auto
 `;
 const Home = () => {
   const navigate = useNavigate();
-  const isLoggedIn = Boolean(getCookieValue(Keys.ACCESS_TOKEN));
+  const [URLSearchParams] = useSearchParams();
+  const [accessToken, setAccessToken] = useRecoilState<Token>(accessTokenAtom);
   const moveToDiaries = () => {
-    setTimeout(() => navigate(PRIVATE_ROUTE.books.path), 4000);
+    setTimeout(() => navigate(PRIVATE_ROUTE.books.path), 3000);
+  };
+  const checkAccessToken = () => {
+    if (accessToken) return moveToDiaries();
   };
 
-  useEffect(() => {
-    if (isLoggedIn) return moveToDiaries;
+  useDidMountEffect(() => {
+    const isSNSLogin = URLSearchParams.get("snslogin") === "success";
+    if (isSNSLogin) refreshToken(setAccessToken);
+    checkAccessToken();
+  }, [accessToken]);
+
+  useDidMountEffect(() => {
+    checkAccessToken();
   }, []);
 
   return (
@@ -35,7 +49,7 @@ const Home = () => {
         <Greeting />
         <GrapeIcon />
       </Fade>
-      {!isLoggedIn && (
+      {!accessToken && (
         <Fade bottom duration={3000}>
           <LoginSection>
             <EmailLoginContainer />

--- a/client/src/recoil/token/atom.ts
+++ b/client/src/recoil/token/atom.ts
@@ -1,8 +1,12 @@
 import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
+
+const { persistAtom } = recoilPersist();
 
 export type Token = string | undefined;
 
 export const accessTokenAtom = atom<Token>({
   key: "accessTokenAtom",
   default: undefined,
+  effects_UNSTABLE: [persistAtom],
 });

--- a/client/src/recoil/token/atom.ts
+++ b/client/src/recoil/token/atom.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+export type Token = string | undefined;
+
+export const accessTokenAtom = atom<Token>({
+  key: "accessTokenAtom",
+  default: undefined,
+});

--- a/client/src/recoil/token/index.ts
+++ b/client/src/recoil/token/index.ts
@@ -1,0 +1,1 @@
+export { accessTokenAtom } from "./atom";

--- a/client/src/utils/token.ts
+++ b/client/src/utils/token.ts
@@ -1,0 +1,14 @@
+import { API_URL } from "src/constants/API_URL";
+import { post } from "./api";
+import { Token } from "src/recoil/token/atom";
+
+export const refreshToken = async (setAccessToken: (arg: Token) => void) => {
+  try {
+    const response = await post(API_URL.refreshToken);
+    setAccessToken(response.accessToken);
+  } catch {
+    alert("로그인이 필요합니다 🪪");
+    // MEMO: access token은 살아있는데 refresh token은 만료된 상황 위해 임시 처리 23.01.31
+    setAccessToken(undefined);
+  }
+};

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7723,6 +7723,11 @@ rechoir@^0.8.0:
   dependencies:
     resolve "^1.20.0"
 
+recoil-persist@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/recoil-persist/-/recoil-persist-4.2.0.tgz#9fbb4a8c158cbb83ceb9dedf795aee24ed15395d"
+  integrity sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==
+
 recoil@^0.7.6:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.6.tgz#75297ecd70bbfeeb72e861aa6141a86bb6dfcd5e"


### PR DESCRIPTION
## 🚀 PR Type

- [x] Bugfix
- [x] Feature

## 🤹‍♀️ What is the current behavior?

- [x] access token cookie에 저장 X -> recoil access token state 추가
- [x] home component에서 access token state 구독하고 이 state가 바뀔 때 access token 받아오기.
- [x] sns login 성공하면 ?snslogin=success 쿼리로 받음. ?snslogin=success 일 때만 토큰 갱신 요청 (refresh token으로 access token 받아오기)
- [x] access token 있는지 확인 후 있으면 일기장 리스트로 redirect
- [x] 페이지 첫 렌더링 시 access token 있는지 확인 후 있으면 일기장 리스트로 redirect (로그인 상태로 home url로 접근한 상황 고려)

Issue Number: resolved #46 
