### PR TITLE
[FE] 일기장 생성 페이지 api 연결, 디자인 수정 및 리팩토링

### DIFF
--- a/client/src/components/common/PurpleButton.tsx
+++ b/client/src/components/common/PurpleButton.tsx
@@ -5,26 +5,12 @@ interface ButtonProps {
   readonly description: string;
   readonly wrapperStyle: string;
   readonly buttonStyle: string;
-  readonly onClickFunc?: unknown;
-  readonly onClickFuncArgs?: unknown;
 }
 
-const PurpleButton = ({
-  description,
-  wrapperStyle,
-  buttonStyle,
-  onClickFunc,
-  onClickFuncArgs,
-}: ButtonProps) => {
+const PurpleButton = ({ description, wrapperStyle, buttonStyle }: ButtonProps) => {
   return (
     <div className={`text-center ${wrapperStyle}`}>
-      <button
-        className={`purple-button text-base sm:text-xl ${buttonStyle}`}
-        role="button"
-        onClick={(e) => {
-          if (typeof onClickFunc === "function") return onClickFunc(e, onClickFuncArgs);
-        }}
-      >
+      <button className={`purple-button text-base sm:text-xl ${buttonStyle}`} role="button">
         {description}
       </button>
     </div>

--- a/client/src/components/new-book/BookTitleInputContainer.tsx
+++ b/client/src/components/new-book/BookTitleInputContainer.tsx
@@ -1,9 +1,33 @@
 import React from "react";
 import { useState } from "react";
 import tw from "tailwind-styled-components";
-import { useSetRecoilState } from "recoil";
 
-import { bookTitleAtom } from "src/recoil/new-book";
+interface TitleContainerProps {
+  register: object;
+}
+
+const BookTitleInputContainer = ({ register }: TitleContainerProps) => {
+  const [letterCount, setLetterCount] = useState(0);
+
+  return (
+    <div className="w-[85%] flex rounded-md bg-white/60 p-3 mx-auto mt-[1.5vh] ">
+      <TitleInput
+        placeholder="일기장 제목을 입력하세요."
+        type="text"
+        maxLength={12}
+        minLength={1}
+        required
+        {...register}
+        onChange={(e) => {
+          setLetterCount(e.target.value.length);
+        }}
+      ></TitleInput>
+      <LetterCount>{letterCount}/12</LetterCount>
+    </div>
+  );
+};
+
+export default BookTitleInputContainer;
 
 const TitleInput = tw.input`
   font-[notosans] bg-transparent ml-[5px] w-[70%] sm:text-lg
@@ -12,24 +36,3 @@ const TitleInput = tw.input`
 const LetterCount = tw.div`
   font-[notosans] text-gray-1000 ml-auto mr-[5px]
 `;
-const BookTitleInputContainer = () => {
-  const [letterCount, setLetterCount] = useState(0);
-  const setDiaryTitle = useSetRecoilState(bookTitleAtom);
-  return (
-    <div className="w-[85%] flex rounded-md bg-white/60 p-3 mx-auto mt-[1.5vh] ">
-      <TitleInput
-        placeholder="일기장 제목을 입력하세요."
-        type="text"
-        maxLength={10}
-        minLength={1}
-        onChange={(e) => {
-          setLetterCount(e.target.value.length);
-          setDiaryTitle(e.target.value);
-        }}
-      ></TitleInput>
-      <LetterCount>{letterCount}/10</LetterCount>
-    </div>
-  );
-};
-
-export default BookTitleInputContainer;

--- a/client/src/components/new-book/ColorSelectContainer.tsx
+++ b/client/src/components/new-book/ColorSelectContainer.tsx
@@ -5,10 +5,6 @@ import { useRecoilState } from "recoil";
 import { selectedColorAtom } from "../../recoil/new-book";
 import { DIARY_COLOR } from "src/constants/DIARY_COLOR";
 
-const ColorSelectButton = tw.div`
-md:w-[65px] w-[35px] md:h-[65px] h-[35px] rounded-full m-auto mb-[2vh] cursor-pointer
-`;
-
 const renderColorSelectButtons = () => {
   const [selectedColor, setSelectedColor] = useRecoilState(selectedColorAtom);
 
@@ -35,3 +31,7 @@ const ColorSelectContainer = () => {
 };
 
 export default ColorSelectContainer;
+
+const ColorSelectButton = tw.div`
+md:w-[65px] w-[35px] md:h-[65px] h-[35px] rounded-full m-auto mb-[2vh] cursor-pointer
+`;

--- a/client/src/components/new-book/ColorSelectContainer.tsx
+++ b/client/src/components/new-book/ColorSelectContainer.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useEffect } from "react";
 import tw from "tailwind-styled-components";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useResetRecoilState } from "recoil";
 
 import { selectedColorAtom } from "../../recoil/new-book";
 import { DIARY_COLOR } from "src/constants/DIARY_COLOR";
@@ -25,6 +25,14 @@ const renderColorSelectButtons = () => {
 };
 
 const ColorSelectContainer = () => {
+  const resetSelectedColor = useResetRecoilState(selectedColorAtom);
+
+  useEffect(() => {
+    return () => {
+      resetSelectedColor();
+    };
+  }, []);
+
   return (
     <div className="grid grid-cols-6 mt-[1.5vh] px-[5vw]">{renderColorSelectButtons()}</div>
   );

--- a/client/src/constants/WARNING_MESSAGE.tsx
+++ b/client/src/constants/WARNING_MESSAGE.tsx
@@ -1,7 +1,0 @@
-interface MessageObj {
-  readonly [key: string]: string;
-}
-
-export const WARNING_MESSAGE: MessageObj = {
-  titleLength: "제목을 한 글자 이상 입력해주세요! ✍️",
-};

--- a/client/src/pages/NewBook.tsx
+++ b/client/src/pages/NewBook.tsx
@@ -3,8 +3,7 @@ import { useRecoilValue } from "recoil";
 import Bounce from "react-reveal/Bounce";
 
 import { post } from "src/utils/api";
-import { selectedColorAtom, bookTitleAtom } from "../recoil/new-book";
-import { WARNING_MESSAGE } from "src/constants/WARNING_MESSAGE";
+import { selectedColorAtom } from "../recoil/new-book";
 import { PinkPurpleBackground } from "src/components/common/Backgrounds";
 import BackButton from "src/components/common/BackButton";
 import PageTitle from "src/components/common/PageTitle";
@@ -15,26 +14,25 @@ import BookTitleInputContainer from "src/components/new-book/BookTitleInputConta
 import PurpleButton from "src/components/common/PurpleButton";
 import { accessTokenAtom } from "src/recoil/token";
 import { API_URL } from "src/constants/API_URL";
+import { useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
 
-interface CreateNewDiaryArgs {
-  color: string;
-  name: string;
+interface NewBookName {
+  bookName: string;
 }
 
 const NewBook = () => {
+  const navigate = useNavigate();
   const accessToken = useRecoilValue(accessTokenAtom);
   const selectedColor = useRecoilValue(selectedColorAtom);
-  const diaryTitle = useRecoilValue(bookTitleAtom);
+  const { register, handleSubmit } = useForm<NewBookName>({
+    mode: "onChange",
+  });
 
-  const createNewDiary = async (
-    e: React.ChangeEvent<HTMLInputElement>,
-    { color, name }: CreateNewDiaryArgs
-  ) => {
+  const createNewDiary = async ({ bookName }: NewBookName) => {
     try {
-      if (diaryTitle.length < 1) return alert(WARNING_MESSAGE.titleLength);
-      await post(API_URL.books, { color, name }, accessToken);
-      //  TODO: api 완성되는대로 db로 데이터 post하도록 변경하기 23.01.25
-      return { selectedColor, diaryTitle };
+      await post(API_URL.books, { color: selectedColor, bookName }, accessToken);
+      navigate(-1);
     } catch (err) {
       alert(err);
     }
@@ -44,18 +42,14 @@ const NewBook = () => {
       <BackButton />
       <PageTitle title="일기장 만들기" />
       <Bounce duration={1500}>
-        <DiaryIcon />
-        <ContainerTitle>표지 색상 선택</ContainerTitle>
-        <ColorSelectContainer />
-        <ContainerTitle>일기장 제목</ContainerTitle>
-        <BookTitleInputContainer />
-        <PurpleButton
-          description="생성하기"
-          wrapperStyle="mt-[5vh]"
-          buttonStyle="sm:w-40"
-          onClickFunc={createNewDiary}
-          onClickFuncArgs={{ selectedColor, diaryTitle }}
-        />
+        <form onSubmit={handleSubmit(createNewDiary)}>
+          <DiaryIcon />
+          <ContainerTitle>표지 색상 선택</ContainerTitle>
+          <ColorSelectContainer />
+          <ContainerTitle>일기장 제목</ContainerTitle>
+          <BookTitleInputContainer register={register("bookName")} />
+          <PurpleButton description="생성하기" wrapperStyle="mt-[5vh]" buttonStyle="sm:w-40" />
+        </form>
       </Bounce>
     </PinkPurpleBackground>
   );

--- a/client/src/pages/NewBook.tsx
+++ b/client/src/pages/NewBook.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { useRecoilValue } from "recoil";
+import Bounce from "react-reveal/Bounce";
 
-import { PurpleBackground } from "src/components/common/Backgrounds";
+import { post } from "src/utils/api";
+import { selectedColorAtom, bookTitleAtom } from "../recoil/new-book";
+import { WARNING_MESSAGE } from "src/constants/WARNING_MESSAGE";
+import { PinkPurpleBackground } from "src/components/common/Backgrounds";
 import BackButton from "src/components/common/BackButton";
 import PageTitle from "src/components/common/PageTitle";
 import DiaryIcon from "src/components/new-book/DiaryIcon";
@@ -9,47 +13,51 @@ import ColorSelectContainer from "src/components/new-book/ColorSelectContainer";
 import ContainerTitle from "src/components/new-book/ContainerTitle";
 import BookTitleInputContainer from "src/components/new-book/BookTitleInputContainer";
 import PurpleButton from "src/components/common/PurpleButton";
-import { selectedColorAtom, bookTitleAtom } from "../recoil/new-book";
-import { WARNING_MESSAGE } from "src/constants/WARNING_MESSAGE";
+import { accessTokenAtom } from "src/recoil/token";
+import { API_URL } from "src/constants/API_URL";
 
 interface CreateNewDiaryArgs {
-  selectedColor: string;
-  diaryTitle: string;
+  color: string;
+  name: string;
 }
 
-const createNewDiary = (
-  e: React.ChangeEvent<HTMLInputElement>,
-  { selectedColor, diaryTitle }: CreateNewDiaryArgs
-) => {
-  try {
-    if (diaryTitle.length < 1) return alert(WARNING_MESSAGE.titleLength);
-    //  TODO: api 완성되는대로 db로 데이터 post하도록 변경하기 23.01.25
-    return { selectedColor, diaryTitle };
-  } catch (err) {
-    alert(err);
-  }
-};
-
 const NewBook = () => {
+  const accessToken = useRecoilValue(accessTokenAtom);
   const selectedColor = useRecoilValue(selectedColorAtom);
   const diaryTitle = useRecoilValue(bookTitleAtom);
+
+  const createNewDiary = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+    { color, name }: CreateNewDiaryArgs
+  ) => {
+    try {
+      if (diaryTitle.length < 1) return alert(WARNING_MESSAGE.titleLength);
+      await post(API_URL.books, { color, name }, accessToken);
+      //  TODO: api 완성되는대로 db로 데이터 post하도록 변경하기 23.01.25
+      return { selectedColor, diaryTitle };
+    } catch (err) {
+      alert(err);
+    }
+  };
   return (
-    <PurpleBackground>
+    <PinkPurpleBackground>
       <BackButton />
       <PageTitle title="일기장 만들기" />
-      <DiaryIcon />
-      <ContainerTitle>표지 색상 선택</ContainerTitle>
-      <ColorSelectContainer />
-      <ContainerTitle>일기장 제목</ContainerTitle>
-      <BookTitleInputContainer />
-      <PurpleButton
-        description="생성하기"
-        wrapperStyle="mt-[5vh]"
-        buttonStyle="sm:w-40"
-        onClickFunc={createNewDiary}
-        onClickFuncArgs={{ selectedColor, diaryTitle }}
-      />
-    </PurpleBackground>
+      <Bounce duration={1500}>
+        <DiaryIcon />
+        <ContainerTitle>표지 색상 선택</ContainerTitle>
+        <ColorSelectContainer />
+        <ContainerTitle>일기장 제목</ContainerTitle>
+        <BookTitleInputContainer />
+        <PurpleButton
+          description="생성하기"
+          wrapperStyle="mt-[5vh]"
+          buttonStyle="sm:w-40"
+          onClickFunc={createNewDiary}
+          onClickFuncArgs={{ selectedColor, diaryTitle }}
+        />
+      </Bounce>
+    </PinkPurpleBackground>
   );
 };
 

--- a/client/src/recoil/new-book/atom.js
+++ b/client/src/recoil/new-book/atom.js
@@ -4,8 +4,3 @@ export const selectedColorAtom = atom({
   key: "selectedColor",
   default: "000000",
 });
-
-export const bookTitleAtom = atom({
-  key: "bookTitle",
-  default: "",
-});

--- a/client/src/recoil/new-book/index.js
+++ b/client/src/recoil/new-book/index.js
@@ -1,1 +1,1 @@
-export { selectedColorAtom, bookTitleAtom } from "./atom";
+export { selectedColorAtom } from "./atom";


### PR DESCRIPTION
## 🚀 PR Type
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)


## 🤹‍♀️ What is the current behavior?

- [x] recoil title atom, 버튼에 submit callback 함수 전달 방식에서 react-hooks-form 이용하도록 구현방법 변경
- [x] 일기장 생성 post api 연결
- [x] 일기장 색상 cleanup 기능 추가
- [x] 배경화면 변경, animation 추가

Issue Number: resolved #80

## 📸 Screenshots
**before**
<img width="400" alt="image" src="https://user-images.githubusercontent.com/111125577/216772418-5500a643-3fd4-4764-93f4-85d8e4a93f32.png">

**after**
<img width="400" alt="image" src="https://user-images.githubusercontent.com/111125577/216772391-0e06dc06-3e07-4c71-961a-89f2e0819014.png">

