### PR TITLE
[FE] 다중데이터 post시 사진 항목을 비워서 보내면 오류 발생하는 이슈 해결

### DIFF
--- a/client/src/components/new-diary/NewDiaryForm.tsx
+++ b/client/src/components/new-diary/NewDiaryForm.tsx
@@ -18,7 +18,7 @@ interface DiaryInput {
 
 const createDiaryForm = (diaryImg: Img, bookId: string, { title, content }: DiaryInput) => {
   const formData = new FormData();
-  formData.append("picture", diaryImg);
+  if (diaryImg) formData.append("picture", diaryImg);
   formData.append("bookId", bookId);
   formData.append("title", title);
   formData.append("content", content);

--- a/client/src/components/sign-up/EmailSignUpContainer.tsx
+++ b/client/src/components/sign-up/EmailSignUpContainer.tsx
@@ -22,7 +22,7 @@ interface SignUpInput {
 
 const createSignUpForm = (profileImg: Img, { nickname, email, password }: SignUpInput) => {
   const formData = new FormData();
-  formData.append("profile", profileImg);
+  if (profileImg) formData.append("profile", profileImg);
   formData.append("nickname", nickname);
   formData.append("email", email);
   formData.append("password", password);


### PR DESCRIPTION
## 🚀 PR Type

- [x] Bugfix

## 🤹‍♀️ What is the current behavior?

- [x] 다중 데이터 post 전 사진 데이터가 비어있으면 form data에 추가하지 않도록 코드 추가

Issue Number: resolved #101
