### PR TITLE
[FE] 글 리스트 페이지 - 붙은 스티커 보여주기, drag and drop 기능

### DIFF
--- a/client/src/components/book/DiaryContainer.tsx
+++ b/client/src/components/book/DiaryContainer.tsx
@@ -1,13 +1,14 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import tw from "tailwind-styled-components";
 import { useNavigate } from "react-router-dom";
 import Fade from "react-reveal/Fade";
 
 import { PRIVATE_ROUTE } from "src/router/ROUTE_INFO";
-import changeToKoreanTime from "src/utils/time";
 import { Diary } from "./DiaryListContainer";
-import DefaultProfileImg from "../../assets/icons/default_profile.png";
 import commentImg from "../../assets/icons/comment.png";
+import { AffixedSticker, AffixedStickerInfo } from "../common/diary/Sticker";
+import { DiarySectionContainer } from "../common/diary/DiarySectionContainer";
+import { DiarySection } from "../common/diary/DiarySection";
 
 interface DiaryContainerProps {
   viewRef?: () => void;
@@ -15,9 +16,6 @@ interface DiaryContainerProps {
 }
 
 const DiaryContainer = ({ viewRef, data }: DiaryContainerProps) => {
-  const profileImgSrc = data.profile === "없음" ? DefaultProfileImg : data.profile;
-  const hasPicture = data.picture !== "없음";
-  const isRevised = data.createdAt !== data.updatedAt;
   const navigate = useNavigate();
   const onClickDiary = () => {
     navigate(`${PRIVATE_ROUTE.books.path}/${data.bookId}/${data.diaryId}`, {
@@ -27,72 +25,56 @@ const DiaryContainer = ({ viewRef, data }: DiaryContainerProps) => {
     });
   };
 
+  const [stickers, setStickers] = useState<AffixedStickerInfo[]>([]);
+  const handleUpdateStickers = (newSticker: AffixedStickerInfo) => {
+    setStickers((curStickers) => {
+      return [
+        ...curStickers.filter(
+          (sticker) => sticker.stickedStickerId !== newSticker.stickedStickerId
+        ),
+        newSticker,
+      ];
+    });
+  };
+  useEffect(() => {
+    if (data.stickers) setStickers(data.stickers);
+  }, []);
+
   return (
     <Fade bottom duration={1000}>
-      <Container onClick={onClickDiary} ref={viewRef}>
-        <div className="flex">
-          <ProfileImg src={profileImgSrc}></ProfileImg>
-          <div className="my-auto">
-            <Nickname>{data.nickname}</Nickname>
-            <div className="flex">
-              <Date>{changeToKoreanTime(data.updatedAt)}</Date>
-              {isRevised && <Date className="ml-1">(수정됨)</Date>}
-            </div>
-          </div>
-        </div>
-        {hasPicture && <Photo src={String(data.picture)} />}
-        <DiaryTitle>{data.title}</DiaryTitle>
-        <DiaryContent>{data.content}</DiaryContent>
+      <DiarySectionContainer className={ContainerStyle} onClick={onClickDiary} ref={viewRef}>
+        {stickers.map((sticker) => {
+          return (
+            <AffixedSticker
+              key={sticker.stickedStickerId}
+              sticker={sticker}
+              handleUpdateStickers={handleUpdateStickers}
+            />
+          );
+        })}
+        <DiarySection data={data} isDetailPage={false} />
         <CommentContainer>
           <CommentIcon src={commentImg} />
           <NumComments>{data.numComments}</NumComments>
         </CommentContainer>
-      </Container>
+      </DiarySectionContainer>
     </Fade>
   );
 };
 
 export default DiaryContainer;
 
-const Container = tw.div`
-cursor-pointer bg-white/60 rounded-lg 
-shadow-lg hover:shadow-none ease-in duration-200
-mx-auto mb-[2vh] w-[90%]
-`;
-
-const ProfileImg = tw.img`
-w-[45px] h-[45px] min-[390px]:w-[60px] min-[390px]:h-[60px] md:w-[65px] md:h-[65px] 
-rounded-full object-cover shadow-lg ml-4 my-4 mr-2 md:ml-6 md:my-6 md:mr-4
-`;
-
-const Nickname = tw.p`
-text-[1.8vh] md:text-[1.5vh]
-`;
-
-const Date = tw.p`
-text-gray-1000 text-[1.5vh] md:text-[1.3vh]
-`;
-
-const Photo = tw.img`
-w-[70%] mx-6 md:mx-8
-`;
-
-const DiaryTitle = tw.p`
-mx-6 md:mx-8 mt-2 text-[2.2vh] md:text-[2vh]
-whitespace-pre-line break-all
-`;
-
-const DiaryContent = tw.p`
-mx-6 md:mx-8 pb-4 md:pb-6 text-[1.8vh] md:text-[1.6vh] 
-whitespace-pre-line break-all
+const ContainerStyle = `
+cursor-pointer mb-[2vh]
+hover:shadow-none ease-in duration-200
 `;
 
 const CommentContainer = tw.div`
-flex justify-end mr-6 md:mr-8 pb-4 md:pb-6
+flex justify-end 
 `;
 
 const CommentIcon = tw.img`
-w-[25px] h-[25px] min-[390px]:w-[34px] min-[390px]:h-[34px] md:w-[37px] md:w-[37px] my-auto
+w-[25px] h-[25px] min-[390px]:w-[34px] min-[390px]:h-[34px] md:w-[37px] my-auto
 `;
 
 const NumComments = tw.p`

--- a/client/src/components/book/DiaryListContainer.tsx
+++ b/client/src/components/book/DiaryListContainer.tsx
@@ -18,6 +18,7 @@ export interface Diary {
   content: string;
   profile: null | string;
   picture: null | string;
+  stickers: null | [];
   createdAt: Date;
   updatedAt: Date;
   numComments: number;


### PR DESCRIPTION
## 🚀 PR Type

- [x] Feature
- [x] Refactoring (no functional changes, no api changes)


## 🤹‍♀️ What is the current behavior?

- [x] 일기에 붙여진 스티커들 불러와서 맞는 위치에 보여주기 
- [x] 일기 상세 페이지와 같은 위치에 스티커 붙도록 일기 컴포넌트 재활용
- [x] 스티커들 치우고 볼 수 있게 drag and drop 기능 추가
- [x] moveable box 기본 테두리 안 보이게 처리

Issue Number: resolves #165

## 📸 Screenshots
**figma 캡쳐**
<img width="400" alt="image" src="https://user-images.githubusercontent.com/111125577/219865139-08be9645-fc49-4b22-b600-5df906c99d3c.png">
**완성된 화면**
<img width="400" alt="image" src="https://user-images.githubusercontent.com/111125577/219865422-07436fb8-4307-4dbe-82e3-1964820adf44.png">
