### PR TITLE
[FE] 댓글 작성/수정/삭제 시 UI 업데이트 방법 개선

### DIFF
--- a/client/src/components/diary-detail/Comment.tsx
+++ b/client/src/components/diary-detail/Comment.tsx
@@ -67,7 +67,9 @@ export const Comment = ({
           commentId={data.commentId}
           comment={data.reply}
           parentNickname={parentNickname}
-          setIsBeingEdited={setIsBeingEdited}
+          cancelEdit={() => {
+            setIsBeingEdited(false);
+          }}
         ></EditComment>
       )}
     </SingleCommentContainer>

--- a/client/src/components/diary-detail/CommentSection.tsx
+++ b/client/src/components/diary-detail/CommentSection.tsx
@@ -64,12 +64,13 @@ export const CommentSection = ({ diaryId }: DiaryId) => {
           <CommentsFamily
             diaryId={diaryId}
             commentsFam={commentsFam}
+            getComments={getComments}
             key={commentsFam.parentComment?.commentId}
           />
         );
       })}
       <div className="h-[2vh]" />
-      <NewComment diaryId={diaryId} />
+      <NewComment diaryId={diaryId} getComments={getComments} />
     </div>
   );
 };

--- a/client/src/components/diary-detail/CommentSection.tsx
+++ b/client/src/components/diary-detail/CommentSection.tsx
@@ -1,11 +1,8 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import tw from "tailwind-styled-components";
 import { useRecoilValue } from "recoil";
 
-import { accessTokenAtom } from "src/recoil/token";
-import { focusedDiaryIdAtom } from "src/recoil/diary-detail/atom";
-import { API_URL } from "src/constants/API_URL";
-import { get } from "src/utils/api";
+import { getComments } from "src/recoil/diary-detail";
 import { NewComment } from "./NewComment";
 import { CommentsFamily } from "./CommentsFamily";
 
@@ -26,43 +23,26 @@ export interface CommentFamType {
 }
 
 export const CommentSection = () => {
-  const accessToken = useRecoilValue(accessTokenAtom);
-  const diaryId = useRecoilValue(focusedDiaryIdAtom);
-  const [commentsFamArr, setCommentsFamArr] = useState<CommentFamType[]>([]);
-  const reCommentsSum = commentsFamArr.reduce((accumulator, currentObj) => {
+  const comments = useRecoilValue<CommentFamType[]>(getComments);
+  const reCommentsSum = comments.reduce((accumulator, currentObj) => {
     if (currentObj.reComments) return accumulator + currentObj.reComments.length;
     return accumulator;
   }, 0);
 
-  const getComments = async () => {
-    try {
-      if (!diaryId) return;
-      const response = await get(API_URL.diaryComments(diaryId), "", accessToken);
-      setCommentsFamArr(response.data);
-    } catch (err) {
-      if (err instanceof Error) alert(err.message);
-    }
-  };
-
-  useEffect(() => {
-    getComments();
-  }, []);
-
   return (
     <div className="pb-6 md:pb-8">
       <Divider />
-      <NumCommentsWrapper>댓글 {commentsFamArr.length + reCommentsSum}</NumCommentsWrapper>
-      {commentsFamArr.map((commentsFam) => {
+      <NumCommentsWrapper>댓글 {comments.length + reCommentsSum}</NumCommentsWrapper>
+      {comments.map((commentsFam) => {
         return (
           <CommentsFamily
             commentsFam={commentsFam}
-            getComments={getComments}
             key={commentsFam.parentComment?.commentId}
           />
         );
       })}
       <div className="h-[2vh]" />
-      <NewComment getComments={getComments} />
+      <NewComment />
     </div>
   );
 };

--- a/client/src/components/diary-detail/CommentSection.tsx
+++ b/client/src/components/diary-detail/CommentSection.tsx
@@ -25,15 +25,6 @@ export interface CommentFamType {
   reComments?: CommentType[];
 }
 
-const sortCommentByCreatedTime = (data: CommentFamType[]) => {
-  data.sort(function (a, b) {
-    if (a.parentComment.createdAt > b.parentComment.createdAt) return 1;
-    if (a.parentComment.createdAt < b.parentComment.createdAt) return -1;
-    return 0;
-  });
-  return data;
-};
-
 export const CommentSection = () => {
   const accessToken = useRecoilValue(accessTokenAtom);
   const diaryId = useRecoilValue(focusedDiaryIdAtom);
@@ -47,7 +38,7 @@ export const CommentSection = () => {
     try {
       if (!diaryId) return;
       const response = await get(API_URL.diaryComments(diaryId), "", accessToken);
-      setCommentsFamArr(sortCommentByCreatedTime(response.data));
+      setCommentsFamArr(response.data);
     } catch (err) {
       if (err instanceof Error) alert(err.message);
     }

--- a/client/src/components/diary-detail/CommentSection.tsx
+++ b/client/src/components/diary-detail/CommentSection.tsx
@@ -3,9 +3,9 @@ import tw from "tailwind-styled-components";
 import { useRecoilValue } from "recoil";
 
 import { accessTokenAtom } from "src/recoil/token";
+import { focusedDiaryIdAtom } from "src/recoil/diary-detail/atom";
 import { API_URL } from "src/constants/API_URL";
 import { get } from "src/utils/api";
-import { DiaryId } from "../../pages/DiaryDetail";
 import { NewComment } from "./NewComment";
 import { CommentsFamily } from "./CommentsFamily";
 
@@ -34,8 +34,9 @@ const sortCommentByCreatedTime = (data: CommentFamType[]) => {
   return data;
 };
 
-export const CommentSection = ({ diaryId }: DiaryId) => {
+export const CommentSection = () => {
   const accessToken = useRecoilValue(accessTokenAtom);
+  const diaryId = useRecoilValue(focusedDiaryIdAtom);
   const [commentsFamArr, setCommentsFamArr] = useState<CommentFamType[]>([]);
   const reCommentsSum = commentsFamArr.reduce((accumulator, currentObj) => {
     if (currentObj.reComments) return accumulator + currentObj.reComments.length;
@@ -44,6 +45,7 @@ export const CommentSection = ({ diaryId }: DiaryId) => {
 
   const getComments = async () => {
     try {
+      if (!diaryId) return;
       const response = await get(API_URL.diaryComments(diaryId), "", accessToken);
       setCommentsFamArr(sortCommentByCreatedTime(response.data));
     } catch (err) {
@@ -62,7 +64,6 @@ export const CommentSection = ({ diaryId }: DiaryId) => {
       {commentsFamArr.map((commentsFam) => {
         return (
           <CommentsFamily
-            diaryId={diaryId}
             commentsFam={commentsFam}
             getComments={getComments}
             key={commentsFam.parentComment?.commentId}
@@ -70,7 +71,7 @@ export const CommentSection = ({ diaryId }: DiaryId) => {
         );
       })}
       <div className="h-[2vh]" />
-      <NewComment diaryId={diaryId} getComments={getComments} />
+      <NewComment getComments={getComments} />
     </div>
   );
 };

--- a/client/src/components/diary-detail/CommentsFamily.tsx
+++ b/client/src/components/diary-detail/CommentsFamily.tsx
@@ -1,16 +1,15 @@
 import React, { useState } from "react";
 
-import { DiaryId } from "../../pages/DiaryDetail";
 import { Comment, CommentReply } from "./Comment";
 import { ReplyComment } from "./ReplyComment";
 import { CommentFamType } from "./CommentSection";
 
-interface CommentsFamilyProps extends DiaryId {
+interface CommentsFamilyProps {
   commentsFam: CommentFamType;
   getComments: () => void;
 }
 
-export const CommentsFamily = ({ diaryId, commentsFam, getComments }: CommentsFamilyProps) => {
+export const CommentsFamily = ({ commentsFam, getComments }: CommentsFamilyProps) => {
   const [isReplyWritingEnabled, setIsReplyWritingEnabled] = useState(false);
   const changeReplyState = () => {
     setIsReplyWritingEnabled((prev) => !prev);
@@ -30,7 +29,6 @@ export const CommentsFamily = ({ diaryId, commentsFam, getComments }: CommentsFa
       })}
       {isReplyWritingEnabled && (
         <ReplyComment
-          diaryId={diaryId}
           getComments={getComments}
           changeReplyState={changeReplyState}
           parentNickname={commentsFam.parentComment.nickname}

--- a/client/src/components/diary-detail/CommentsFamily.tsx
+++ b/client/src/components/diary-detail/CommentsFamily.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 
 import { Comment, CommentReply } from "./Comment";
-import { ReplyComment } from "./ReplyComment";
+import { NewCommentReply } from "./NewCommentReply";
 import { CommentFamType } from "./CommentSection";
 
 interface CommentsFamilyProps {
@@ -28,7 +28,7 @@ export const CommentsFamily = ({ commentsFam, getComments }: CommentsFamilyProps
         );
       })}
       {isReplyWritingEnabled && (
-        <ReplyComment
+        <NewCommentReply
           getComments={getComments}
           changeReplyState={changeReplyState}
           parentNickname={commentsFam.parentComment.nickname}

--- a/client/src/components/diary-detail/CommentsFamily.tsx
+++ b/client/src/components/diary-detail/CommentsFamily.tsx
@@ -7,9 +7,10 @@ import { CommentFamType } from "./CommentSection";
 
 interface CommentsFamilyProps extends DiaryId {
   commentsFam: CommentFamType;
+  getComments: () => void;
 }
 
-export const CommentsFamily = ({ diaryId, commentsFam }: CommentsFamilyProps) => {
+export const CommentsFamily = ({ diaryId, commentsFam, getComments }: CommentsFamilyProps) => {
   const [isReplyWritingEnabled, setIsReplyWritingEnabled] = useState(false);
   const changeReplyState = () => {
     setIsReplyWritingEnabled((prev) => !prev);
@@ -30,6 +31,8 @@ export const CommentsFamily = ({ diaryId, commentsFam }: CommentsFamilyProps) =>
       {isReplyWritingEnabled && (
         <ReplyComment
           diaryId={diaryId}
+          getComments={getComments}
+          changeReplyState={changeReplyState}
           parentNickname={commentsFam.parentComment.nickname}
           parentCommentId={commentsFam.parentComment.commentId}
         />

--- a/client/src/components/diary-detail/CommentsFamily.tsx
+++ b/client/src/components/diary-detail/CommentsFamily.tsx
@@ -6,10 +6,9 @@ import { CommentFamType } from "./CommentSection";
 
 interface CommentsFamilyProps {
   commentsFam: CommentFamType;
-  getComments: () => void;
 }
 
-export const CommentsFamily = ({ commentsFam, getComments }: CommentsFamilyProps) => {
+export const CommentsFamily = ({ commentsFam }: CommentsFamilyProps) => {
   const [isReplyWritingEnabled, setIsReplyWritingEnabled] = useState(false);
   const changeReplyState = () => {
     setIsReplyWritingEnabled((prev) => !prev);
@@ -29,7 +28,6 @@ export const CommentsFamily = ({ commentsFam, getComments }: CommentsFamilyProps
       })}
       {isReplyWritingEnabled && (
         <NewCommentReply
-          getComments={getComments}
           changeReplyState={changeReplyState}
           parentNickname={commentsFam.parentComment.nickname}
           parentCommentId={commentsFam.parentComment.commentId}

--- a/client/src/components/diary-detail/DeleteModal.tsx
+++ b/client/src/components/diary-detail/DeleteModal.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import tw from "tailwind-styled-components";
 import Fade from "react-reveal/Fade";
 
 import { accessTokenAtom } from "src/recoil/token";
-import { deleteInfoAtom } from "src/recoil/diary-detail";
+import { deleteInfoAtom, getComments } from "src/recoil/diary-detail";
 import { del } from "src/utils/api";
 import { API_URL } from "src/constants/API_URL";
 import PurpleButton from "../common/PurpleButton";
@@ -16,13 +16,15 @@ interface ModalProps {
 const DeleteModal = ({ onClose }: ModalProps) => {
   const accessToken = useRecoilValue(accessTokenAtom);
   const deleteInfo = useRecoilValue(deleteInfoAtom);
+  const reloadComments = useSetRecoilState(getComments);
 
   const onClickDelete = async () => {
     const apiUrl = deleteInfo.target === "diary" ? API_URL.diary : API_URL.comments;
     try {
       await del(apiUrl, String(deleteInfo.id), accessToken);
       if (deleteInfo.target === "diary") return window.history.back();
-      return window.location.reload();
+      reloadComments(1);
+      onClose();
     } catch (err) {
       if (err instanceof Error) alert(err.message);
     }

--- a/client/src/components/diary-detail/EditComment.tsx
+++ b/client/src/components/diary-detail/EditComment.tsx
@@ -30,10 +30,7 @@ export const EditComment = ({
   const accessToken = useRecoilValue(accessTokenAtom);
   const reloadComments = useSetRecoilState(getComments);
   const { register, handleSubmit } = useForm<CommentInput>({
-    mode: "onChange",
-    defaultValues: {
-      comment: comment,
-    },
+    defaultValues: { comment: comment },
   });
 
   const onSubmitComment = async ({ comment }: CommentInput) => {

--- a/client/src/components/diary-detail/EditComment.tsx
+++ b/client/src/components/diary-detail/EditComment.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import tw from "tailwind-styled-components";
 import { useForm } from "react-hook-form";
 import Fade from "react-reveal/Fade";
 
 import { accessTokenAtom } from "src/recoil/token";
+import { getComments } from "src/recoil/diary-detail";
 import { API_URL } from "src/constants/API_URL";
 import { patch } from "src/utils/api";
 import { Input, InputContainer } from "../common/Input";
@@ -17,16 +18,17 @@ export interface NewCommentProps {
   parentNickname?: string;
   commentId: number;
   comment: string;
-  setIsBeingEdited: (state: boolean) => void;
+  cancelEdit: () => void;
 }
 
 export const EditComment = ({
   parentNickname,
   commentId,
   comment,
-  setIsBeingEdited,
+  cancelEdit,
 }: NewCommentProps) => {
   const accessToken = useRecoilValue(accessTokenAtom);
+  const reloadComments = useSetRecoilState(getComments);
   const { register, handleSubmit } = useForm<CommentInput>({
     mode: "onChange",
     defaultValues: {
@@ -37,7 +39,8 @@ export const EditComment = ({
   const onSubmitComment = async ({ comment }: CommentInput) => {
     try {
       await patch(API_URL.comments, String(commentId), { reply: comment }, accessToken);
-      window.location.reload();
+      reloadComments(1);
+      cancelEdit();
     } catch (err) {
       if (err instanceof Error) alert(err.message);
     }
@@ -62,7 +65,7 @@ export const EditComment = ({
               required
               {...register("comment")}
             />
-            <CancelButton onClick={() => setIsBeingEdited(false)}>취소</CancelButton>
+            <CancelButton onClick={cancelEdit}>취소</CancelButton>
             <PostButton>수정</PostButton>
           </InputContainer>
         </form>

--- a/client/src/components/diary-detail/NewComment.tsx
+++ b/client/src/components/diary-detail/NewComment.tsx
@@ -14,17 +14,25 @@ interface CommentInput {
 }
 
 export interface NewCommentProps extends DiaryId {
+  getComments: () => void;
+  changeReplyState?: () => void;
   parentCommentId?: number;
 }
 
-export const NewComment = ({ diaryId, parentCommentId = 0 }: NewCommentProps) => {
+export const NewComment = ({
+  diaryId,
+  getComments,
+  changeReplyState,
+  parentCommentId = 0,
+}: NewCommentProps) => {
   const accessToken = useRecoilValue(accessTokenAtom);
   const { register, handleSubmit } = useForm<CommentInput>({ mode: "onChange" });
 
   const onSubmitComment = async ({ comment }: CommentInput) => {
     try {
       await post(API_URL.comments, { diaryId, parentCommentId, reply: comment }, accessToken);
-      window.location.reload();
+      getComments();
+      if (changeReplyState) changeReplyState();
     } catch (err) {
       if (err instanceof Error) alert(err.message);
     }

--- a/client/src/components/diary-detail/NewComment.tsx
+++ b/client/src/components/diary-detail/NewComment.tsx
@@ -23,7 +23,7 @@ export const NewComment = ({ changeReplyState, parentCommentId = 0 }: NewComment
   const accessToken = useRecoilValue(accessTokenAtom);
   const diaryId = useRecoilValue(focusedDiaryIdAtom);
   const reloadComments = useSetRecoilState(getComments);
-  const { register, handleSubmit } = useForm<CommentInput>({ mode: "onChange" });
+  const { register, handleSubmit } = useForm<CommentInput>({ mode: "onSubmit" });
 
   const onSubmitComment = async ({ comment }: CommentInput) => {
     try {
@@ -34,6 +34,7 @@ export const NewComment = ({ changeReplyState, parentCommentId = 0 }: NewComment
       if (err instanceof Error) alert(err.message);
     }
   };
+
   return (
     <form onSubmit={handleSubmit(onSubmitComment)}>
       <InputContainer className="flex-row w-full mt-0 shadow-lg">

--- a/client/src/components/diary-detail/NewComment.tsx
+++ b/client/src/components/diary-detail/NewComment.tsx
@@ -4,28 +4,28 @@ import tw from "tailwind-styled-components";
 import { useForm } from "react-hook-form";
 
 import { accessTokenAtom } from "src/recoil/token";
+import { focusedDiaryIdAtom } from "src/recoil/diary-detail/atom";
 import { API_URL } from "src/constants/API_URL";
 import { post } from "src/utils/api";
 import { Input, InputContainer } from "../common/Input";
-import { DiaryId } from "../../pages/DiaryDetail";
 
 interface CommentInput {
   readonly comment: string;
 }
 
-export interface NewCommentProps extends DiaryId {
+export interface NewCommentProps {
   getComments: () => void;
   changeReplyState?: () => void;
   parentCommentId?: number;
 }
 
 export const NewComment = ({
-  diaryId,
   getComments,
   changeReplyState,
   parentCommentId = 0,
 }: NewCommentProps) => {
   const accessToken = useRecoilValue(accessTokenAtom);
+  const diaryId = useRecoilValue(focusedDiaryIdAtom);
   const { register, handleSubmit } = useForm<CommentInput>({ mode: "onChange" });
 
   const onSubmitComment = async ({ comment }: CommentInput) => {

--- a/client/src/components/diary-detail/NewComment.tsx
+++ b/client/src/components/diary-detail/NewComment.tsx
@@ -23,12 +23,13 @@ export const NewComment = ({ changeReplyState, parentCommentId = 0 }: NewComment
   const accessToken = useRecoilValue(accessTokenAtom);
   const diaryId = useRecoilValue(focusedDiaryIdAtom);
   const reloadComments = useSetRecoilState(getComments);
-  const { register, handleSubmit } = useForm<CommentInput>({ mode: "onSubmit" });
+  const { register, handleSubmit, setValue } = useForm<CommentInput>({ mode: "onSubmit" });
 
   const onSubmitComment = async ({ comment }: CommentInput) => {
     try {
       await post(API_URL.comments, { diaryId, parentCommentId, reply: comment }, accessToken);
       reloadComments(1);
+      setValue("comment", "");
       if (changeReplyState) changeReplyState();
     } catch (err) {
       if (err instanceof Error) alert(err.message);

--- a/client/src/components/diary-detail/NewComment.tsx
+++ b/client/src/components/diary-detail/NewComment.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import tw from "tailwind-styled-components";
 import { useForm } from "react-hook-form";
 
@@ -8,30 +8,27 @@ import { focusedDiaryIdAtom } from "src/recoil/diary-detail/atom";
 import { API_URL } from "src/constants/API_URL";
 import { post } from "src/utils/api";
 import { Input, InputContainer } from "../common/Input";
+import { getComments } from "src/recoil/diary-detail";
 
 interface CommentInput {
   readonly comment: string;
 }
 
 export interface NewCommentProps {
-  getComments: () => void;
   changeReplyState?: () => void;
   parentCommentId?: number;
 }
 
-export const NewComment = ({
-  getComments,
-  changeReplyState,
-  parentCommentId = 0,
-}: NewCommentProps) => {
+export const NewComment = ({ changeReplyState, parentCommentId = 0 }: NewCommentProps) => {
   const accessToken = useRecoilValue(accessTokenAtom);
   const diaryId = useRecoilValue(focusedDiaryIdAtom);
+  const reloadComments = useSetRecoilState(getComments);
   const { register, handleSubmit } = useForm<CommentInput>({ mode: "onChange" });
 
   const onSubmitComment = async ({ comment }: CommentInput) => {
     try {
       await post(API_URL.comments, { diaryId, parentCommentId, reply: comment }, accessToken);
-      getComments();
+      reloadComments(1);
       if (changeReplyState) changeReplyState();
     } catch (err) {
       if (err instanceof Error) alert(err.message);

--- a/client/src/components/diary-detail/NewCommentReply.tsx
+++ b/client/src/components/diary-detail/NewCommentReply.tsx
@@ -8,7 +8,6 @@ interface NewCommentReplyProps extends NewCommentProps {
 }
 
 export const NewCommentReply = ({
-  getComments,
   changeReplyState,
   parentNickname,
   parentCommentId = 0,
@@ -20,11 +19,7 @@ export const NewCommentReply = ({
           <div className="font-sans font-bold">{parentNickname}</div>
           <div className="font-sans">님에게 답글 남기는중</div>
         </div>
-        <NewComment
-          getComments={getComments}
-          changeReplyState={changeReplyState}
-          parentCommentId={parentCommentId}
-        />
+        <NewComment changeReplyState={changeReplyState} parentCommentId={parentCommentId} />
         <div className="h-[1vh]" />
       </>
     </Fade>

--- a/client/src/components/diary-detail/NewCommentReply.tsx
+++ b/client/src/components/diary-detail/NewCommentReply.tsx
@@ -3,15 +3,16 @@ import Fade from "react-reveal/Fade";
 
 import { NewCommentProps, NewComment } from "./NewComment";
 
-interface ReplyCommentProps extends NewCommentProps {
+interface NewCommentReplyProps extends NewCommentProps {
   parentNickname: string;
 }
-export const ReplyComment = ({
+
+export const NewCommentReply = ({
   getComments,
   changeReplyState,
   parentNickname,
   parentCommentId = 0,
-}: ReplyCommentProps) => {
+}: NewCommentReplyProps) => {
   return (
     <Fade bottom>
       <>

--- a/client/src/components/diary-detail/ReplyComment.tsx
+++ b/client/src/components/diary-detail/ReplyComment.tsx
@@ -7,7 +7,6 @@ interface ReplyCommentProps extends NewCommentProps {
   parentNickname: string;
 }
 export const ReplyComment = ({
-  diaryId,
   getComments,
   changeReplyState,
   parentNickname,
@@ -21,7 +20,6 @@ export const ReplyComment = ({
           <div className="font-sans">님에게 답글 남기는중</div>
         </div>
         <NewComment
-          diaryId={diaryId}
           getComments={getComments}
           changeReplyState={changeReplyState}
           parentCommentId={parentCommentId}

--- a/client/src/components/diary-detail/ReplyComment.tsx
+++ b/client/src/components/diary-detail/ReplyComment.tsx
@@ -8,6 +8,8 @@ interface ReplyCommentProps extends NewCommentProps {
 }
 export const ReplyComment = ({
   diaryId,
+  getComments,
+  changeReplyState,
   parentNickname,
   parentCommentId = 0,
 }: ReplyCommentProps) => {
@@ -18,7 +20,12 @@ export const ReplyComment = ({
           <div className="font-sans font-bold">{parentNickname}</div>
           <div className="font-sans">님에게 답글 남기는중</div>
         </div>
-        <NewComment diaryId={diaryId} parentCommentId={parentCommentId} />
+        <NewComment
+          diaryId={diaryId}
+          getComments={getComments}
+          changeReplyState={changeReplyState}
+          parentCommentId={parentCommentId}
+        />
         <div className="h-[1vh]" />
       </>
     </Fade>

--- a/client/src/components/diary-detail/StickerSaveBtn.tsx
+++ b/client/src/components/diary-detail/StickerSaveBtn.tsx
@@ -3,26 +3,27 @@ import tw from "tailwind-styled-components";
 import { useRecoilValue } from "recoil";
 
 import { accessTokenAtom } from "src/recoil/token";
+import { focusedDiaryIdAtom } from "src/recoil/diary-detail/atom";
 import { post } from "src/utils/api";
 import { API_URL } from "src/constants/API_URL";
 import { EditingStickerInfo } from "src/pages/DiaryDetail";
-import { AffixedStickerInfo } from "../common/diary/Sticker";
+import { AffixedStickerInfo } from "src/components/common/diary/Sticker";
 
 interface StickerSaveButtonProps {
-  diaryId: number;
   selectedStickers: EditingStickerInfo[];
   handleUpdateStickers: (newSticker: AffixedStickerInfo) => void;
   handleResetSelectedStcks: () => void;
   changeStickerEditState: () => void;
 }
 const StickerSaveBtn = ({
-  diaryId,
   selectedStickers,
   handleUpdateStickers,
   handleResetSelectedStcks,
   changeStickerEditState,
 }: StickerSaveButtonProps) => {
   const accessToken = useRecoilValue(accessTokenAtom);
+  const diaryId = useRecoilValue(focusedDiaryIdAtom);
+
   const refineStickersData = () => {
     const stickersData = selectedStickers.map((sticker) => {
       const { stickerId, locX, locY } = sticker;

--- a/client/src/components/diary-revision/DiaryRevisionForm.tsx
+++ b/client/src/components/diary-revision/DiaryRevisionForm.tsx
@@ -33,7 +33,6 @@ const DiaryRevisionForm = () => {
   const [isPicChanged, setIsPicChanged] = useState(false);
   const [ogData, setOgData] = useState<DiaryOgInput | null>(null);
   const { register, handleSubmit } = useForm<DiaryInput>({
-    mode: "onChange",
     defaultValues: async () => {
       const response = await get(API_URL.bookDiary(Number(bookId)), diaryId, accessToken);
       const { title, picture, content } = response.data;

--- a/client/src/components/edit-info/EditNickname.tsx
+++ b/client/src/components/edit-info/EditNickname.tsx
@@ -19,10 +19,7 @@ const EditNickname = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { register, handleSubmit } = useForm<NicknameInput>({
-    mode: "onChange",
-    defaultValues: {
-      nickname: location.state.myInfo.nickname,
-    },
+    defaultValues: { nickname: location.state.myInfo.nickname },
   });
 
   const onSubmitEdit = async ({ nickname }: NicknameInput) => {

--- a/client/src/components/edit-info/EditPassword.tsx
+++ b/client/src/components/edit-info/EditPassword.tsx
@@ -26,7 +26,7 @@ const EditPassword = () => {
     handleSubmit,
     getValues,
     formState: { errors },
-  } = useForm<PasswordInput>({ mode: "onSubmit" });
+  } = useForm<PasswordInput>({ mode: "onChange" });
   const pwConfirmRegister = register("newPwConfirm", {
     validate: (pwconfirm: string | undefined) => {
       const { newPassword } = getValues();

--- a/client/src/components/edit-info/EditPassword.tsx
+++ b/client/src/components/edit-info/EditPassword.tsx
@@ -26,9 +26,7 @@ const EditPassword = () => {
     handleSubmit,
     getValues,
     formState: { errors },
-  } = useForm<PasswordInput>({
-    mode: "onChange",
-  });
+  } = useForm<PasswordInput>({ mode: "onSubmit" });
   const pwConfirmRegister = register("newPwConfirm", {
     validate: (pwconfirm: string | undefined) => {
       const { newPassword } = getValues();

--- a/client/src/components/home/EmailLoginContainer.tsx
+++ b/client/src/components/home/EmailLoginContainer.tsx
@@ -20,7 +20,7 @@ interface loginInput {
 }
 
 const EmailLoginContainer = ({ tokenExpireTime, refreshTime }: LoginProps) => {
-  const { register, handleSubmit } = useForm<loginInput>({ mode: "onChange" });
+  const { register, handleSubmit } = useForm<loginInput>({ mode: "onSubmit" });
   const setAccessToken = useSetRecoilState(accessTokenAtom);
 
   const logIn = async ({ email, password }: loginInput) => {

--- a/client/src/components/my-page/InviteCodeSection.tsx
+++ b/client/src/components/my-page/InviteCodeSection.tsx
@@ -16,9 +16,7 @@ interface InviteCodeInput {
 export const InviteCodeSection = () => {
   const accessToken = useRecoilValue(accessTokenAtom);
   const navigate = useNavigate();
-  const { register, handleSubmit } = useForm<InviteCodeInput>({
-    mode: "onChange",
-  });
+  const { register, handleSubmit } = useForm<InviteCodeInput>({ mode: "onSubmit" });
   const onSubmitCode = async ({ invttCode }: InviteCodeInput) => {
     try {
       await post(API_URL.inviteCodeInput, { invttCode }, accessToken);

--- a/client/src/components/new-diary/NewDiaryForm.tsx
+++ b/client/src/components/new-diary/NewDiaryForm.tsx
@@ -28,7 +28,7 @@ const NewDiaryForm = () => {
   const bookId = String(params.bookId);
   const accessToken = useRecoilValue(accessTokenAtom);
   const diaryImg = useRecoilValue(diaryImgAtom);
-  const { register, handleSubmit } = useForm<DiaryInput>({ mode: "onChange" });
+  const { register, handleSubmit } = useForm<DiaryInput>({ mode: "onSubmit" });
 
   const onSubmitDiaryForm = async ({ title, content }: DiaryInput) => {
     const formData = createDiaryForm(diaryImg, bookId, { title, content });

--- a/client/src/pages/BookRevision.tsx
+++ b/client/src/pages/BookRevision.tsx
@@ -34,10 +34,7 @@ const BookRevision = () => {
   const [isRevised, setIsRevised] = useState(false);
   const [buttonCursorStyle, setButtonCursorStyle] = useState("");
   const { register, handleSubmit } = useForm<BookNameType>({
-    mode: "onChange",
-    defaultValues: {
-      bookName: location.state.name,
-    },
+    defaultValues: { bookName: location.state.name },
   });
   const refreshIsTitleRevised = (currentTitle: string) => {
     setIsTitleRevised(currentTitle !== location.state.name);

--- a/client/src/pages/DiaryDetail.tsx
+++ b/client/src/pages/DiaryDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, Suspense } from "react";
 import { useParams, useLocation } from "react-router-dom";
 import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
 import { v4 as uuidv4 } from "uuid";
@@ -146,7 +146,9 @@ const DiaryDetail = () => {
           )}
           <DiarySection data={data} isDetailPage={true} />
           <StickerButton changeEditState={changeStickerEditState} />
-          <CommentSection />
+          <Suspense fallback={<div>loading...</div>}>
+            <CommentSection />
+          </Suspense>
           {isDeleteModalVisible && (
             <DeleteModal
               onClose={() => {

--- a/client/src/pages/DiaryDetail.tsx
+++ b/client/src/pages/DiaryDetail.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect, Suspense } from "react";
 import { useParams, useLocation } from "react-router-dom";
-import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
+import {
+  useRecoilState,
+  useRecoilValue,
+  useSetRecoilState,
+  useResetRecoilState,
+} from "recoil";
 import { v4 as uuidv4 } from "uuid";
 import Fade from "react-reveal/Fade";
 
@@ -32,7 +37,7 @@ const DiaryDetail = () => {
   const params = useParams();
   const location = useLocation();
   const data = location.state.diaryInfo;
-  const [diaryId, setDiaryId] = useRecoilState(focusedDiaryIdAtom);
+  const setDiaryId = useSetRecoilState(focusedDiaryIdAtom);
   const accessToken = useRecoilValue(accessTokenAtom);
 
   const [isEditingSticker, setIsEditingSticker] = useState<boolean>(false);
@@ -48,7 +53,7 @@ const DiaryDetail = () => {
   const [stickers, setStickers] = useState<AffixedStickerInfo[]>([]);
   const getAffixedStickers = async () => {
     try {
-      const response = await get(API_URL.stickers(diaryId), "", accessToken);
+      const response = await get(API_URL.stickers(Number(params.diaryId)), "", accessToken);
       setStickers(response.data);
     } catch (err) {
       if (err instanceof Error) alert(err.message);

--- a/client/src/pages/DiaryDetail.tsx
+++ b/client/src/pages/DiaryDetail.tsx
@@ -4,7 +4,7 @@ import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
 import { v4 as uuidv4 } from "uuid";
 import Fade from "react-reveal/Fade";
 
-import { isDeleteModalVisibleAtom } from "../recoil/diary-detail/atom";
+import { focusedDiaryIdAtom, isDeleteModalVisibleAtom } from "../recoil/diary-detail/atom";
 import { accessTokenAtom } from "src/recoil/token";
 import { PinkPurpleBackground } from "src/components/common/Backgrounds";
 import BackButton from "../components/common/BackButton";
@@ -20,10 +20,6 @@ import EditingSticker from "src/components/diary-detail/EditingSticker";
 import { get } from "src/utils/api";
 import { API_URL } from "src/constants/API_URL";
 
-export interface DiaryId {
-  diaryId: number;
-}
-
 export interface EditingStickerInfo extends StickerInfo {
   uniqueId: string;
   locX: number;
@@ -33,10 +29,10 @@ export interface EditingStickerInfo extends StickerInfo {
 const DiaryDetail = () => {
   const DEFAULT_STKR_POS_X = 10;
   const DEFAULT_STKR_POS_Y = 10;
+  const params = useParams();
   const location = useLocation();
   const data = location.state.diaryInfo;
-  const params = useParams();
-  const diaryId = Number(params.diaryId);
+  const [diaryId, setDiaryId] = useRecoilState(focusedDiaryIdAtom);
   const accessToken = useRecoilValue(accessTokenAtom);
 
   const [isEditingSticker, setIsEditingSticker] = useState<boolean>(false);
@@ -69,6 +65,7 @@ const DiaryDetail = () => {
     });
   };
   useEffect(() => {
+    setDiaryId(Number(params.diaryId));
     getAffixedStickers();
   }, []);
 
@@ -116,7 +113,6 @@ const DiaryDetail = () => {
       <BackButton />
       {isEditingSticker && (
         <StickerSaveBtn
-          diaryId={diaryId}
           selectedStickers={selectedStickers}
           handleUpdateStickers={handleUpdateAffixedStickers}
           handleResetSelectedStcks={handleResetSelectedStcks}
@@ -150,7 +146,7 @@ const DiaryDetail = () => {
           )}
           <DiarySection data={data} isDetailPage={true} />
           <StickerButton changeEditState={changeStickerEditState} />
-          <CommentSection diaryId={diaryId} />
+          <CommentSection />
           {isDeleteModalVisible && (
             <DeleteModal
               onClose={() => {

--- a/client/src/pages/NewBook.tsx
+++ b/client/src/pages/NewBook.tsx
@@ -25,9 +25,7 @@ const NewBook = () => {
   const navigate = useNavigate();
   const accessToken = useRecoilValue(accessTokenAtom);
   const selectedColor = useRecoilValue(selectedColorAtom);
-  const { register, handleSubmit } = useForm<NewBookName>({
-    mode: "onChange",
-  });
+  const { register, handleSubmit } = useForm<NewBookName>({ mode: "onSubmit" });
 
   const createNewDiary = async ({ bookName }: NewBookName) => {
     try {

--- a/client/src/recoil/diary-detail/atom.ts
+++ b/client/src/recoil/diary-detail/atom.ts
@@ -14,6 +14,11 @@ export const focusedDiaryIdAtom = atom<number>({
   effects_UNSTABLE: [persistAtom],
 });
 
+export const forceRefreshCommentsAtom = atom<number>({
+  key: "forceReloadCommentsAtom",
+  default: 0,
+});
+
 export const isDeleteModalVisibleAtom = atom<boolean>({
   key: "isDeleteModalVisibleAtom",
   default: false,

--- a/client/src/recoil/diary-detail/atom.ts
+++ b/client/src/recoil/diary-detail/atom.ts
@@ -1,4 +1,7 @@
 import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
+
+const { persistAtom } = recoilPersist();
 
 export interface DeleteInfo {
   id: number | undefined;
@@ -8,6 +11,7 @@ export interface DeleteInfo {
 export const focusedDiaryIdAtom = atom<number>({
   key: "focusedDiaryIdAtom",
   default: undefined,
+  effects_UNSTABLE: [persistAtom],
 });
 
 export const isDeleteModalVisibleAtom = atom<boolean>({

--- a/client/src/recoil/diary-detail/atom.ts
+++ b/client/src/recoil/diary-detail/atom.ts
@@ -5,6 +5,11 @@ export interface DeleteInfo {
   target: "diary" | "comment" | undefined;
 }
 
+export const focusedDiaryIdAtom = atom<number>({
+  key: "focusedDiaryIdAtom",
+  default: undefined,
+});
+
 export const isDeleteModalVisibleAtom = atom<boolean>({
   key: "isDeleteModalVisibleAtom",
   default: false,

--- a/client/src/recoil/diary-detail/index.ts
+++ b/client/src/recoil/diary-detail/index.ts
@@ -1,1 +1,23 @@
+import { selector } from "recoil";
+
+import { API_URL } from "src/constants/API_URL";
+import { focusedDiaryIdAtom } from "src/recoil/diary-detail/atom";
+import { accessTokenAtom } from "../token";
+import * as api from "src/utils/api";
+
 export { focusedDiaryIdAtom, isDeleteModalVisibleAtom, deleteInfoAtom } from "./atom";
+
+export const getComments = selector({
+  key: "getComments",
+  get: async ({ get }) => {
+    const diaryId = get(focusedDiaryIdAtom);
+    const accessToken = get(accessTokenAtom);
+
+    try {
+      const response = await api.get(API_URL.diaryComments(diaryId), "", accessToken);
+      return response.data;
+    } catch (err) {
+      if (err instanceof Error) alert(err.message);
+    }
+  },
+});

--- a/client/src/recoil/diary-detail/index.ts
+++ b/client/src/recoil/diary-detail/index.ts
@@ -1,1 +1,1 @@
-export { isDeleteModalVisibleAtom, deleteInfoAtom } from "./atom";
+export { focusedDiaryIdAtom, isDeleteModalVisibleAtom, deleteInfoAtom } from "./atom";

--- a/client/src/recoil/diary-detail/index.ts
+++ b/client/src/recoil/diary-detail/index.ts
@@ -1,7 +1,7 @@
 import { selector } from "recoil";
 
 import { API_URL } from "src/constants/API_URL";
-import { focusedDiaryIdAtom } from "src/recoil/diary-detail/atom";
+import { forceRefreshCommentsAtom, focusedDiaryIdAtom } from "src/recoil/diary-detail/atom";
 import { accessTokenAtom } from "../token";
 import * as api from "src/utils/api";
 
@@ -10,6 +10,7 @@ export { focusedDiaryIdAtom, isDeleteModalVisibleAtom, deleteInfoAtom } from "./
 export const getComments = selector({
   key: "getComments",
   get: async ({ get }) => {
+    get(forceRefreshCommentsAtom);
     const diaryId = get(focusedDiaryIdAtom);
     const accessToken = get(accessTokenAtom);
 
@@ -19,5 +20,8 @@ export const getComments = selector({
     } catch (err) {
       if (err instanceof Error) alert(err.message);
     }
+  },
+  set: ({ set }) => {
+    return set(forceRefreshCommentsAtom, Math.random());
   },
 });


### PR DESCRIPTION
## 🚀 PR Type

- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## 🤹‍♀️ What is the current behavior?

- [x] 댓글 수정, 생성, 삭제 시 reload하던 방식에서 댓글 정보를 다시 받아와서(비관적 업데이트 채택) 댓글 부분만 렌더링하도록 변경
- [x] 선택된 diaryId atom 추가, 전역 state로 설정해 props drilling 방지
- [x] diaryId를 구독중인 get comment selector, diaryId가 바뀔 때 실행해 comments 정보 get해옴 

🤔**고민한 점** 
selector의 key값과 get해서 구독중인 atom의 state value로(recoil은 참조 동등성 대신 값 동등성 사용) 이전에 fetch한 것이 있다면 cache에서 바로 처리하기 때문에 diaryId가 바뀌지 않고 서버의 정보가 바뀐 경우에 동일한 댓글을 리턴함.
✅ **해결한 방법** 
selector가 구독중인 atom의 상태가 변경되면 다시 업데이트 된다는 점을 이용해 refresh state를 하나 만들어서 selector가 구독하게 만들고 api 요청이 필요할 때 해당 refresh state를 변경시키기. [useRecoilRefresher](https://recoiljs.org/docs/api-reference/core/useRecoilRefresher/)라는 api를 사용할 수도 있음. (unstable)

- [x] refresh atom 추가, get comments selector에서 구독하게 한 뒤 get comments setter에서 refresh state 변경
- [x] comment를 다시 받아와야하는 댓글 생성/수정/삭제 작업 후 get comments setter 실행
- [x] 댓글 생성/수정 후 입력창 비우고 편집모드 끄기, 댓글 삭제 후 모달창 닫기
- [x] Suspense로 댓글 받아오는 비동기 작업 중 loading 상태 보여주기
- [x] 백엔드 댓글 시간 순 정렬 기능 추가에 따른 정렬 함수 삭제

Issue Number: resolves #194 

## 💬 Other information

```typescript
export const getComments = selector({
  key: "getComments",
  get: async ({ get }) => {
    get(forceRefreshCommentsAtom);
    const diaryId = get(focusedDiaryIdAtom);
    const accessToken = get(accessTokenAtom);
    try {
      const response = await api.get(API_URL.diaryComments(diaryId), "", accessToken);
      return response.data;
    } catch (err) {
      if (err instanceof Error) alert(err.message);
    }
  },
  set: ({ set }) => {
    return set(forceRefreshCommentsAtom, Math.random());
  },
});
```


```typescript
  const reloadComments = useSetRecoilState(getComments);

  const onSubmitComment = async ({ comment }: CommentInput) => {
    await post(API_URL.comments, { diaryId, parentCommentId, reply: comment }, accessToken);
    reloadComments(1);
  };
```