### PR TITLE
[FE] 일기장 리스트 페이지 진입 시 화면 깜빡임 버그 수정

### DIFF
--- a/client/src/components/book-list/BookButton.tsx
+++ b/client/src/components/book-list/BookButton.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import tw from "tailwind-styled-components";
 import { useNavigate } from "react-router-dom";
 import { PRIVATE_ROUTE } from "src/router/ROUTE_INFO";
-import { DiaryInfo } from "src/pages/BookList";
+import { BookInfo } from "src/pages/BookList";
 
-export const BookButton = ({ bookId, bookName, numMembers, color }: DiaryInfo) => {
+export const BookButton = ({ bookId, bookName, numMembers, color }: BookInfo) => {
   const navigate = useNavigate();
   const onClickImg = () => {
     navigate(PRIVATE_ROUTE.books.path + "/" + bookId, {

--- a/client/src/components/book-list/BooksContainer.tsx
+++ b/client/src/components/book-list/BooksContainer.tsx
@@ -1,19 +1,17 @@
 import React from "react";
 import Fade from "react-reveal/Fade";
 
-import { DiaryInfo } from "src/pages/BookList";
+import { DiaryArr, DiaryInfo } from "src/pages/BookList";
 import { HeartDiaryButton } from "src/components/book-list/HeartDiaryButton";
 import { BookButton } from "src/components/book-list/BookButton";
 import { NewBookButton } from "./NewBookButton";
 
 interface DiaryContainerProps {
   isEmpty: boolean;
-  userDiaryArr: DiaryInfo[] | undefined;
+  userDiaryArr: DiaryArr;
 }
 
-const renderDiaryButtons = (
-  userDiaryArr: DiaryInfo[] | undefined
-): JSX.Element[] | undefined => {
+const renderDiaryButtons = (userDiaryArr: DiaryArr): JSX.Element[] | undefined => {
   const diaryButtons = userDiaryArr?.map((diary: DiaryInfo) => {
     return (
       <BookButton

--- a/client/src/components/book-list/BooksContainer.tsx
+++ b/client/src/components/book-list/BooksContainer.tsx
@@ -1,40 +1,37 @@
 import React from "react";
 import Fade from "react-reveal/Fade";
 
-import { DiaryArr, DiaryInfo } from "src/pages/BookList";
+import { BooksArr, BookInfo } from "src/pages/BookList";
 import { HeartDiaryButton } from "src/components/book-list/HeartDiaryButton";
 import { BookButton } from "src/components/book-list/BookButton";
 import { NewBookButton } from "./NewBookButton";
 
-interface DiaryContainerProps {
+interface BookContainerProps {
   isEmpty: boolean;
-  userDiaryArr: DiaryArr;
+  userBooksArr: BooksArr;
 }
 
-const renderDiaryButtons = (userDiaryArr: DiaryArr): JSX.Element[] | undefined => {
-  const diaryButtons = userDiaryArr?.map((diary: DiaryInfo) => {
+const renderBookButtons = (userBooksArr: BooksArr): JSX.Element[] | undefined => {
+  const bookButtons = userBooksArr?.map((book: BookInfo) => {
     return (
       <BookButton
-        key={diary.bookId}
-        bookId={diary.bookId}
-        bookName={diary.bookName}
-        numMembers={diary.numMembers}
-        color={diary.color}
+        key={book.bookId}
+        bookId={book.bookId}
+        bookName={book.bookName}
+        numMembers={book.numMembers}
+        color={book.color}
       />
     );
   });
-  return diaryButtons;
+  return bookButtons;
 };
 
-export const BooksContainer = ({
-  isEmpty,
-  userDiaryArr,
-}: DiaryContainerProps): JSX.Element => {
+export const BooksContainer = ({ isEmpty, userBooksArr }: BookContainerProps) => {
   if (isEmpty) return <HeartDiaryButton />;
   return (
     <Fade duration={3000}>
       <div className="flex flex-wrap justify-center mt-[3vh]">
-        {renderDiaryButtons(userDiaryArr)}
+        {renderBookButtons(userBooksArr)}
         <NewBookButton />
       </div>
     </Fade>

--- a/client/src/pages/BookList.tsx
+++ b/client/src/pages/BookList.tsx
@@ -12,18 +12,18 @@ import { PointingFinger } from "src/components/book-list/PointingFinger";
 import { BooksContainer } from "src/components/book-list/BooksContainer";
 import { Navbar } from "src/components/common/NavBar";
 
-export interface DiaryInfo {
+export interface BookInfo {
   readonly bookId: number;
   readonly bookName: string;
   readonly numMembers: number;
   readonly color: string;
 }
 
-export type DiaryArr = DiaryInfo[] | null;
+export type BooksArr = BookInfo[] | null;
 
 const BookList = () => {
   const accessToken = useRecoilValue(accessTokenAtom);
-  const [userDiaryArr, setUserDiaryArr] = useState<DiaryArr>(null);
+  const [userBooksArr, setUserBooksArr] = useState<BooksArr>(null);
   const [isEmpty, setIsEmpty] = useState<boolean>(true);
   async function getUserBookArr() {
     try {
@@ -33,23 +33,23 @@ const BookList = () => {
       alert(err);
     }
   }
-  const handleUserDiaryArr = async () => {
+  const handleUserBooksArr = async () => {
     const userDiaries = await getUserBookArr();
-    setUserDiaryArr(userDiaries);
+    setUserBooksArr(userDiaries);
   };
 
   useEffect(() => {
-    handleUserDiaryArr();
+    handleUserBooksArr();
   }, []);
 
-  useEffect(() => setIsEmpty(userDiaryArr?.length === 0 ? true : false), [userDiaryArr]);
+  useEffect(() => setIsEmpty(userBooksArr?.length === 0 ? true : false), [userBooksArr]);
 
   return (
     <PinkPurpleBackground>
       <div className="h-[89vh] overflow-y-scroll">
         <Guidance isEmpty={isEmpty}></Guidance>
         <PointingFinger />
-        <BooksContainer isEmpty={isEmpty} userDiaryArr={userDiaryArr} />
+        <BooksContainer isEmpty={isEmpty} userBooksArr={userBooksArr} />
       </div>
       <Navbar activeMenu="books" />
     </PinkPurpleBackground>

--- a/client/src/pages/BookList.tsx
+++ b/client/src/pages/BookList.tsx
@@ -19,9 +19,11 @@ export interface DiaryInfo {
   readonly color: string;
 }
 
+export type DiaryArr = DiaryInfo[] | null;
+
 const BookList = () => {
   const accessToken = useRecoilValue(accessTokenAtom);
-  const [userDiaryArr, setUserDiaryArr] = useState<DiaryInfo[] | undefined>([]);
+  const [userDiaryArr, setUserDiaryArr] = useState<DiaryArr>(null);
   const [isEmpty, setIsEmpty] = useState<boolean>(true);
   async function getUserBookArr() {
     try {


### PR DESCRIPTION
## 🚀 PR Type

- [x] Bugfix

## 🤹‍♀️ What is the current behavior?

- [x] 일기장 리스트 state의 초기값을 빈 리스트 대신 null로 변경
- [x] diary -> book 변수명 수정

Issue Number: resolves #196

## 💬 Other information
일기장 리스트 state의 초기값을 빈 리스트 대신 null로 변경해 일기장 리스트를 받아오기 전 isEmpty 값이 true가 되는 현상을 막음

**before**
 ```typescript
const [userDiaryArr, setUserDiaryArr] = useState<DiaryInfo[] | undefined>([]);

useEffect(() => setIsEmpty(userDiaryArr?.length === 0 ? true : false), [userDiaryArr]);
```
**after**
 ```typescript
const [userBooksArr, setUserBooksArr] = useState<BooksArr>(null);
```

