### PR TITLE
[FE] 댓글 로딩 상태 Skeleton UI 적용

### DIFF
--- a/client/src/components/diary-detail/Comment.tsx
+++ b/client/src/components/diary-detail/Comment.tsx
@@ -86,11 +86,11 @@ const SingleCommentContainer = tw.div`
 mb-2 md:mb-3
 `;
 
-const CommentUpperSection = tw.div`
+export const CommentUpperSection = tw.div`
 flex
 `;
 
-const CommentLowerSection = tw.div`
+export const CommentLowerSection = tw.div`
 flex mt-1 md:mt-2
 `;
 

--- a/client/src/components/diary-detail/CommentSection.tsx
+++ b/client/src/components/diary-detail/CommentSection.tsx
@@ -22,7 +22,11 @@ export interface CommentFamType {
   reComments?: CommentType[];
 }
 
-export const CommentSection = () => {
+interface CommentSectionProps {
+  updateNumComments: (newNumComments: number) => void;
+}
+
+export const CommentSection = ({ updateNumComments }: CommentSectionProps) => {
   const comments = useRecoilValue<CommentFamType[]>(getComments);
   const reloadComments = useSetRecoilState(getComments);
   const reCommentsSum = comments.reduce((accumulator, currentObj) => {
@@ -33,6 +37,9 @@ export const CommentSection = () => {
   useEffect(() => {
     reloadComments(1);
   }, []);
+  useEffect(() => {
+    if (comments.length) updateNumComments(comments.length + reCommentsSum);
+  }, [comments]);
 
   return (
     <div className="pb-6 md:pb-8">
@@ -52,10 +59,10 @@ export const CommentSection = () => {
   );
 };
 
-const Divider = tw.hr`
+export const Divider = tw.hr`
 h-[2px] bg-[#C7C7C7] mx-auto
 `;
 
-const NumCommentsWrapper = tw.div`
+export const NumCommentsWrapper = tw.div`
 mt-2 md:mt-3 mb-1 md:mb-2 mx-auto text-[1.8vh]
 `;

--- a/client/src/components/diary-detail/CommentsSkeleton.tsx
+++ b/client/src/components/diary-detail/CommentsSkeleton.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import Skeleton from "react-loading-skeleton";
+import "react-loading-skeleton/dist/skeleton.css";
+
+import { NewComment } from "./NewComment";
+import { Divider, NumCommentsWrapper } from "./CommentSection";
+import { CommentLowerSection, CommentUpperSection } from "./Comment";
+import tw from "tailwind-styled-components";
+
+interface CommentsSkeletonProps {
+  numComments: number;
+}
+
+const CommentsSkeleton = ({ numComments }: CommentsSkeletonProps) => {
+  const componentArray = Array.from(Array(numComments).keys());
+
+  return (
+    <div className="pb-6 md:pb-8">
+      <Divider />
+      <NumCommentsWrapper>댓글 {numComments}</NumCommentsWrapper>
+      {componentArray.map((idx) => {
+        return (
+          <React.Fragment key={idx}>
+            <CommentUpperSection>
+              <WriterProfile />
+              <div className="w-[90%]">
+                <div className="w-[10%] mb-1 h-[1.6vh] min-[390px]:h-[1.4vh]">
+                  <TextSkeleton />
+                </div>
+                <div className="w-[30%] h-[1.6vh] min-[390px]:h-[1.4vh]">
+                  <TextSkeleton />
+                </div>
+              </div>
+            </CommentUpperSection>
+            <CommentLowerSection>
+              <div className="w-full mb-1 md:mb-2">
+                <TextSkeleton />
+              </div>
+            </CommentLowerSection>
+          </React.Fragment>
+        );
+      })}
+      <div className="h-[2vh]" />
+      <NewComment />
+    </div>
+  );
+};
+
+export default CommentsSkeleton;
+
+const WriterProfile = tw.div`
+w-[30px] h-[30px] min-[390px]:w-[38px] min-[390px]:h-[38px] md:w-[48px] md:h-[48px] 
+rounded-full shadow-lg mr-2 md:mr-3 bg-gray-200
+`;
+
+const TextSkeleton = tw(Skeleton)`
+h-[1.6vh] min-[390px]:h-[1.4vh]
+`;

--- a/client/src/pages/DiaryDetail.tsx
+++ b/client/src/pages/DiaryDetail.tsx
@@ -18,6 +18,7 @@ import StickerButton from "src/components/diary-detail/StickerButton";
 import { CommentSection } from "src/components/diary-detail/CommentSection";
 import DeleteModal from "src/components/diary-detail//DeleteModal";
 import EditingSticker from "src/components/diary-detail/EditingSticker";
+import CommentsSkeleton from "src/components/diary-detail/CommentsSkeleton";
 
 export interface EditingStickerInfo extends StickerInfo {
   uniqueId: string;
@@ -34,6 +35,10 @@ const DiaryDetail = () => {
   const setDiaryId = useSetRecoilState(focusedDiaryIdAtom);
   const resetDiaryId = useResetRecoilState(focusedDiaryIdAtom);
 
+  const [numComments, setNumComments] = useState<number>(data.numComments);
+  const updateNumComments = (newNumComments: number) => {
+    setNumComments(newNumComments);
+  };
   const [isEditingSticker, setIsEditingSticker] = useState<boolean>(false);
   const changeStickerEditState = () => {
     setIsEditingSticker((prev) => !prev);
@@ -151,8 +156,8 @@ const DiaryDetail = () => {
           )}
           <DiarySection data={data} isDetailPage={true} />
           <StickerButton changeEditState={changeStickerEditState} />
-          <Suspense fallback={<div>loading...</div>}>
-            <CommentSection />
+          <Suspense fallback={<CommentsSkeleton numComments={numComments} />}>
+            <CommentSection updateNumComments={updateNumComments} />
           </Suspense>
           {isDeleteModalVisible && (
             <DeleteModal


### PR DESCRIPTION
## 🚀 PR Type

- [x] Feature

## 🤹‍♀️ What is the current behavior?

- [x] 댓글 skeleton 컴포넌트 추가
- [x] 댓글 개수만큼 skeleton 보여주기
  - [x] location state로 받은 댓글 개수를 초기 댓글 개수 state로 설정
  - [x] 이후 댓글 업데이트 될 때 댓글 개수 state 업데이트

Issue Number: resolves #228

## 📸 Screenshots
**before**
<div>
  <img width="350" alt="image" src="https://user-images.githubusercontent.com/111125577/233857269-dd34d76e-8994-4093-af7f-1221f2307d7d.png">
  <img width="350" alt="image" src="https://user-images.githubusercontent.com/111125577/233857145-18a10f60-a101-4149-949c-92ac44e472a6.png">
</div>

**after**
<div>
  <img width="350" alt="image" src="https://user-images.githubusercontent.com/111125577/233856549-19a55885-713d-400d-a8b6-573945422c48.png">
  <img width="350" alt="image" src="https://user-images.githubusercontent.com/111125577/233857145-18a10f60-a101-4149-949c-92ac44e472a6.png">
</div>


