### PR TITLE
[FE] UI 개선 - 포도알 페이지 좌우 스크롤 삭제

### DIFF
--- a/client/src/pages/Grape.tsx
+++ b/client/src/pages/Grape.tsx
@@ -55,7 +55,7 @@ const Grape = () => {
         <div className="h-screen">
           <GrapeInfo data={myGrape} grapeRef={grapeRef} />
           <MoveBtn stickerShopRef={stickerShopRef} isMoveDown={true} />
-          <div className="h-[17vh] w-screen" />
+          <div className="h-[17vh]" />
         </div>
         <S.StickerShopContainer ref={stickerShopRef}>
           <MoveBtn grapeRef={grapeRef} isMoveDown={false} />


### PR DESCRIPTION
## 🚀 PR Type

- [x] Bugfix

## 🤹‍♀️ What is the current behavior?

- [x] 좌우 스크롤바의 원인인 일부 div의 w-screen 옵션을 삭제함

Issue Number: resolves #239

## 📸 Screenshots
**before**
<img width="2298" alt="image" src="https://github.com/sojinjang/podo-log/assets/111125577/9818fc77-590a-4194-9d80-79c37c1910d3">

**after**
<img width="2298" alt="image" src="https://github.com/sojinjang/podo-log/assets/111125577/d6f2193a-8122-4b6d-9052-33efe2a2bc37">
